### PR TITLE
Implement NextAuth auth route and Prisma helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 DATABASE_URL="postgresql://postgres:xNoaqhItFg9h3YOC@db.ahrnrsofcehbivmizbax.supabase.co:5432/postgres"
 NEXTAUTH_SECRET="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFocm5yc29mY2VoYml2bWl6YmF4Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1MDEwNDcyMSwiZXhwIjoyMDY1NjgwNzIxfQ.O4CnAQW1XBwIcYcHMwOTuk3xNohzRuO2l0plTzynQDw"
+GOOGLE_CLIENT_ID="your-google-client-id"
+GOOGLE_CLIENT_SECRET="your-google-client-secret"
+NEXTAUTH_URL="http://localhost:3000"

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,9 +1,49 @@
-"use client";   
-import dynamic from "next/dynamic";
-const Dashboard = dynamic(() => import("@/components/Dashboard"), {
-  ssr: false,
-});
+import { prisma } from '@/lib/prisma'
 
-export default function AdminHome() {
-  return <Dashboard />;
+export default async function AdminDashboard() {
+  const orders = await prisma.order.findMany({
+    include: { user: true },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  const totalOrders = orders.length
+  const totalRevenue = orders.reduce((sum, o) => sum + o.total, 0)
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold">Admin Dashboard</h1>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="bg-white p-4 rounded shadow">
+          <p className="text-sm text-gray-500">Total Orders</p>
+          <p className="text-xl font-bold">{totalOrders}</p>
+        </div>
+        <div className="bg-white p-4 rounded shadow">
+          <p className="text-sm text-gray-500">Total Revenue</p>
+          <p className="text-xl font-bold">${totalRevenue.toFixed(2)}</p>
+        </div>
+      </div>
+      <table className="min-w-full text-sm">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="p-2 text-left">Order ID</th>
+            <th className="p-2 text-left">User Email</th>
+            <th className="p-2 text-left">Total</th>
+            <th className="p-2 text-left">Status</th>
+            <th className="p-2 text-left">Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          {orders.map((o) => (
+            <tr key={o.id} className="border-b">
+              <td className="p-2">{o.id}</td>
+              <td className="p-2">{o.user.email}</td>
+              <td className="p-2">${o.total.toFixed(2)}</td>
+              <td className="p-2">{o.status}</td>
+              <td className="p-2">{o.createdAt.toDateString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
 }

--- a/src/app/admin/products/[id]/page.tsx
+++ b/src/app/admin/products/[id]/page.tsx
@@ -1,0 +1,16 @@
+import { notFound } from 'next/navigation'
+import { prisma } from '@/lib/prisma'
+import ProductForm from '@/components/ProductForm'
+
+interface Props { params: { id: string } }
+
+export default async function EditProductPage({ params }: Props) {
+  const product = await prisma.product.findUnique({ where: { id: Number(params.id) } })
+  if (!product) return notFound()
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold">Edit Product</h1>
+      <ProductForm product={product} />
+    </div>
+  )
+}

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link'
+import { prisma } from '@/lib/prisma'
+
+export default async function ProductsAdminPage() {
+  const products = await prisma.product.findMany({
+    orderBy: { createdAt: 'desc' },
+  })
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold">Products</h1>
+      <table className="min-w-full text-sm">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="p-2 text-left">Product ID</th>
+            <th className="p-2 text-left">Name</th>
+            <th className="p-2 text-left">Price</th>
+            <th className="p-2 text-left">Created At</th>
+            <th className="p-2" />
+          </tr>
+        </thead>
+        <tbody>
+          {products.map((p) => (
+            <tr key={p.id} className="border-b">
+              <td className="p-2">{p.id}</td>
+              <td className="p-2">{p.name}</td>
+              <td className="p-2">${p.price.toFixed(2)}</td>
+              <td className="p-2">{p.createdAt.toDateString()}</td>
+              <td className="p-2 text-right">
+                <Link
+                  href={`/admin/products/${p.id}`}
+                  className="text-blue-600 hover:underline"
+                >
+                  Edit
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,20 +1,46 @@
-// src/app/api/auth/[...nextauth]/route.ts
-import NextAuth from "next-auth";
-import { PrismaAdapter } from "@next-auth/prisma-adapter";
-import { PrismaClient } from "@prisma/client";
+import NextAuth, { type NextAuthOptions } from 'next-auth'
+import { PrismaAdapter } from '@next-auth/prisma-adapter'
+import GoogleProvider from 'next-auth/providers/google'
+import CredentialsProvider from 'next-auth/providers/credentials'
+import { prisma } from '@/lib/prisma'
 
-const prisma = new PrismaClient();
-
-// احفظ authOptions كمجرد ثُغَير محلي:
-const authOptions = {
+export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
   providers: [
-    // هنا ضيف موفّري الدخول لديك
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    }),
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'text' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (!credentials?.email) return null
+        const user = await prisma.user.findUnique({
+          where: { email: credentials.email },
+        })
+        return user
+      },
+    }),
   ],
-};
+  pages: { signIn: '/auth/signin' },
+  session: { strategy: 'jwt' },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) token.role = (user as any).role
+      return token
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.role = token.role as string
+      }
+      return session
+    },
+  },
+}
 
-// أنشئ المعالج:
-const handler = NextAuth(authOptions);
-
-// صَدّر فقط دوال HTTP:
-export { handler as GET, handler as POST };
+const handler = NextAuth(authOptions)
+export { handler as GET, handler as POST }

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,0 +1,30 @@
+import { getProviders } from 'next-auth/react'
+import { signIn } from 'next-auth/react'
+
+function ProviderButtons({ providers }: { providers: Awaited<ReturnType<typeof getProviders>> }) {
+  'use client'
+  if (!providers) return null
+  return (
+    <div className="space-y-2">
+      {Object.values(providers).map((provider) => (
+        <button
+          key={provider.id}
+          onClick={() => signIn(provider.id, { callbackUrl: '/' })}
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          Sign in with {provider.name}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default async function SignInPage() {
+  const providers = await getProviders()
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Sign In</h1>
+      <ProviderButtons providers={providers} />
+    </div>
+  )
+}

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -1,0 +1,51 @@
+'use client'
+import { useCart } from '@/components/cart-context'
+
+export default function CartPage() {
+  const { items, removeItem, updateQty } = useCart()
+  const total = items.reduce((sum, i) => sum + i.price * i.qty, 0)
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Your Cart</h1>
+      {items.length === 0 ? (
+        <p>No items in cart.</p>
+      ) : (
+        <>
+          <ul className="divide-y">
+            {items.map((item) => (
+              <li key={item.id} className="flex justify-between items-center py-2">
+                <div>
+                  <p>{item.name}</p>
+                  <p className="text-sm text-gray-600">${item.price.toFixed(2)}</p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="number"
+                    min="1"
+                    value={item.qty}
+                    onChange={(e) => updateQty(item.id, parseInt(e.target.value))}
+                    className="border p-1 w-16 rounded"
+                  />
+                  <button
+                    onClick={() => removeItem(item.id)}
+                    className="text-red-600"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <div className="font-semibold">Total: ${total.toFixed(2)}</div>
+          <button
+            onClick={() => console.log(items)}
+            className="bg-blue-600 text-white px-4 py-2 rounded"
+          >
+            Checkout
+          </button>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Geist, Geist_Mono } from "next/font/google";
 import type { ReactNode } from "react";
+import { CartProvider } from "@/components/cart-context";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -23,7 +24,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <CartProvider>{children}</CartProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,106 +1,27 @@
-import Image from "next/image";
-import type { FC } from "react";
+import { prisma } from '@/lib/prisma'
+import AddToCartButton from '@/components/AddToCartButton'
 
-const Home: FC = () => {
+export const revalidate = 0
+
+export default async function Storefront() {
+  const products = await prisma.product.findMany({ orderBy: { createdAt: 'desc' } })
+
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
+    <div className="grid gap-6 p-6 md:p-10">
+      <h1 className="text-2xl font-semibold">Products</h1>
+      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
+        {products.map((p) => (
+          <div key={p.id} className="border rounded p-4 space-y-2">
+            <h2 className="font-medium">{p.name}</h2>
+            <p className="text-sm text-gray-600">${p.price.toFixed(2)}</p>
+            <AddToCartButton
+              productId={p.id}
+              name={p.name}
+              price={p.price}
             />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+          </div>
+        ))}
+      </div>
     </div>
-  );
-};
-
-export default Home;
+  )
+}

--- a/src/components/AddToCartButton.tsx
+++ b/src/components/AddToCartButton.tsx
@@ -1,0 +1,22 @@
+'use client'
+import { CartItem, useCart } from './cart-context'
+
+export default function AddToCartButton({
+  productId,
+  name,
+  price,
+}: {
+  productId: number
+  name: string
+  price: number
+}) {
+  const { addItem } = useCart()
+  return (
+    <button
+      onClick={() => addItem({ id: productId, name, price })}
+      className="bg-blue-600 text-white px-2 py-1 rounded"
+    >
+      Add to Cart
+    </button>
+  )
+}

--- a/src/components/ProductForm.tsx
+++ b/src/components/ProductForm.tsx
@@ -1,0 +1,74 @@
+'use client'
+import { useState, useTransition } from 'react'
+import type { Product } from '@prisma/client'
+import { prisma } from '@/lib/prisma'
+import { revalidatePath } from 'next/cache'
+
+export async function updateProduct(formData: FormData) {
+  'use server'
+  const id = Number(formData.get('id'))
+  const name = String(formData.get('name'))
+  const description = String(formData.get('description'))
+  const price = parseFloat(String(formData.get('price')))
+
+  await prisma.product.update({
+    where: { id },
+    data: { name, description, price },
+  })
+  revalidatePath('/admin/products')
+}
+
+export default function ProductForm({ product }: { product: Product }) {
+  const [isPending, startTransition] = useTransition()
+  const [name, setName] = useState(product.name)
+  const [description, setDescription] = useState(product.description ?? '')
+  const [price, setPrice] = useState(product.price)
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+    startTransition(() => updateProduct(formData))
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <input type="hidden" name="id" value={product.id} />
+      <div>
+        <label className="block text-sm">Name</label>
+        <input
+          name="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="border p-2 w-full rounded"
+        />
+      </div>
+      <div>
+        <label className="block text-sm">Description</label>
+        <textarea
+          name="description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="border p-2 w-full rounded"
+        />
+      </div>
+      <div>
+        <label className="block text-sm">Price</label>
+        <input
+          name="price"
+          type="number"
+          step="0.01"
+          value={price}
+          onChange={(e) => setPrice(parseFloat(e.target.value))}
+          className="border p-2 w-full rounded"
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={isPending}
+        className="bg-blue-600 text-white px-4 py-2 rounded"
+      >
+        Save
+      </button>
+    </form>
+  )
+}

--- a/src/components/cart-context.tsx
+++ b/src/components/cart-context.tsx
@@ -1,0 +1,47 @@
+'use client'
+import { createContext, useContext, useState, ReactNode } from 'react'
+
+export type CartItem = { id: number; name: string; price: number; qty: number }
+
+interface CartContextState {
+  items: CartItem[]
+  addItem: (item: Omit<CartItem, 'qty'>) => void
+  removeItem: (id: number) => void
+  updateQty: (id: number, qty: number) => void
+}
+
+const CartContext = createContext<CartContextState | undefined>(undefined)
+
+export function CartProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<CartItem[]>([])
+
+  const addItem = (product: Omit<CartItem, 'qty'>) => {
+    setItems((prev) => {
+      const existing = prev.find((i) => i.id === product.id)
+      if (existing) {
+        return prev.map((i) =>
+          i.id === product.id ? { ...i, qty: i.qty + 1 } : i
+        )
+      }
+      return [...prev, { ...product, qty: 1 }]
+    })
+  }
+
+  const removeItem = (id: number) =>
+    setItems((prev) => prev.filter((i) => i.id !== id))
+
+  const updateQty = (id: number, qty: number) =>
+    setItems((prev) => prev.map((i) => (i.id === id ? { ...i, qty } : i)))
+
+  return (
+    <CartContext.Provider value={{ items, addItem, removeItem, updateQty }}>
+      {children}
+    </CartContext.Provider>
+  )
+}
+
+export function useCart() {
+  const ctx = useContext(CartContext)
+  if (!ctx) throw new Error('useCart must be used within CartProvider')
+  return ctx
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,3 +1,0 @@
-import { PrismaClient } from '@prisma/client';
-
-export const db = new PrismaClient();

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,14 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient
+}
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma
+}
+

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -10,4 +10,8 @@ declare module 'next-auth' {
       role: 'ADMIN' | 'CUSTOMER';
     } & DefaultSession['user'];
   }
+
+  interface JWT {
+    role?: 'ADMIN' | 'CUSTOMER'
+  }
 }


### PR DESCRIPTION
## Summary
- add stable Prisma client wrapper
- wire up NextAuth with Prisma adapter and providers
- expose sign-in page with provider buttons
- update pages to use new Prisma helper
- document auth environment vars
- scaffold admin & storefront pages

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68509a413258832198d98c07c8428929